### PR TITLE
Set Https flag when using SSL

### DIFF
--- a/src/cls/ZPM/UpLink.cls
+++ b/src/cls/ZPM/UpLink.cls
@@ -65,6 +65,7 @@ Method GetHttpRequest()
         Set httprequest.Port = ..Port
     }
     If (..SSL) {
+        Set httprequest.Https = 1
         Set httprequest.SSLConfiguration = ##class(ZPM.Utils).GetSSLConfiguration()
     }
     Return httprequest


### PR DESCRIPTION
Ran into this in a more restricted environment - the current behavior is dependent on (e.g.) http://pm.community.intersystems.com/ redirecting to https://pm.community.intersystems.com/

Would appreciate if we could get a new release out with this (and it looks like at least one other fix) soon!