### PR TITLE
Update image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM intersystems/iris-community:2023.1.0.185.0
+FROM intersystems/iris-community:2024.1
 
 WORKDIR /opt/registry
 


### PR DESCRIPTION
2023.1.0.185.0 no longer starts because the built-in license is expired. Updating to 2024.1.