### PR TITLE
feat: filter versions by prerelease and snapshot in request query str

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -5,7 +5,7 @@
       <Name>zpm-registry</Name>
       <ExternalName>ZPM Registry</ExternalName>
       <Description>Registry server for ZPM</Description>
-      <Version>1.2.9</Version>
+      <Version>1.3.0</Version>
       <Packaging>module</Packaging>
       <Dependencies>
         <ModuleReference>

--- a/src/cls/ZPM/Package.cls
+++ b/src/cls/ZPM/Package.cls
@@ -140,7 +140,18 @@ Method versionsGet() As %ListOfDataTypes
   Set tList = ##class(%ListOfDataTypes).%New()
 
   Set name = ..name
-  &sql(SELECT %DLIST(version) INTO :versions FROM Package WHERE name = :name)
+  Set tPrerelease = $Select($Data(%request) # 2: %request.Get("includePrerelease", 0), 1: 1)
+  Set tSnapshot = $Select($Data(%request) # 2: %request.Get("includeSnapshots", 0), 1: 1)
+  &sql(
+    SELECT %DLIST(version) INTO :versions 
+    FROM Package 
+    WHERE name = :name
+    AND (
+      versionPrerelease IS NULL 
+      OR (:tSnapshot = 1 AND LOWER(versionPrerelease) = 'snapshot')
+      OR (:tPrerelease = 1 AND LOWER(versionPrerelease) <> 'snapshot')
+    )
+  )
   If (SQLCODE=0) {
     Set ptr = 0
     While $ListNext(versions, ptr, version) {
@@ -158,12 +169,19 @@ Method versionsGet() As %ListOfDataTypes
   Return tList
 }
 
-ClassMethod VersionFind(pkg As %String = "", version As %String = "") As %String
+ClassMethod VersionFind(pkg As %String = "", version As %String = "", pPrerelease As %Boolean = 1, pSnapshot As %Boolean = 1) As %String
 {
   If (version = "") || (version = "latest") || (version = "*") {
     // package was published directly in this registry - return the last version
-    &sql(SELECT TOP 1 Version INTO :version FROM ZPM.Package WHERE Name = :pkg AND UpLink IS NULL
-          ORDER BY versionMajor DESC, versionMinor DESC, versionPatch DESC, versionPrerelease DESC, versionBuildmetadata DESC
+    &sql(SELECT TOP 1 Version INTO :version FROM ZPM.Package 
+        WHERE Name = :pkg 
+          AND UpLink IS NULL
+          AND (
+            versionPrerelease IS NULL 
+            OR (:pSnapshot = 1 AND LOWER(versionPrerelease) = 'snapshot')
+            OR (:pPrerelease = 1 AND LOWER(versionPrerelease) <> 'snapshot')
+          )
+        ORDER BY versionMajor DESC, versionMinor DESC, versionPatch DESC, versionPrerelease DESC, versionBuildmetadata DESC
     )
     If SQLCODE=0 { 
       // found 
@@ -171,7 +189,13 @@ ClassMethod VersionFind(pkg As %String = "", version As %String = "") As %String
     } Else {
       // find the latest version in UpLinks 
       Do ##class(ZPM.UpLink).LoadPackageFromAllUpLinks(pkg, "latest")
-      &sql(SELECT TOP 1 Version INTO :version FROM ZPM.Package WHERE Name = :pkg
+      &sql(SELECT TOP 1 Version INTO :version FROM ZPM.Package 
+          WHERE Name = :pkg 
+            AND (
+              versionPrerelease IS NULL 
+              OR (:pSnapshot = 1 AND LOWER(versionPrerelease) = 'snapshot')
+              OR (:pPrerelease = 1 AND LOWER(versionPrerelease) <> 'snapshot')
+            )
           ORDER BY versionMajor DESC, versionMinor DESC, versionPatch DESC, versionPrerelease DESC, versionBuildmetadata DESC
       )
       If SQLCODE=0 { 

--- a/src/cls/ZPM/Registry.cls
+++ b/src/cls/ZPM/Registry.cls
@@ -117,8 +117,10 @@ ClassMethod Package(pkg As %String = "", version As %String = "", platformVersio
   If (version="") {
     $$$ThrowOnError(##class(ZPM.UpLink).FindPackageInAllUpLinks(pkg))
   }
+  Set tIncludePrerelease = %request.Get("includePrerelease", 0)
+  Set tIncludeSnapshots = %request.Get("includeSnapshots", 0)
 
-  Set version = ##class(ZPM.Package).VersionFind(pkg, version)
+  Set version = ##class(ZPM.Package).VersionFind(pkg, version, tIncludePrerelease, tIncludeSnapshots)
   If (version = "") {
     Return ..ReportHttpStatusCode(..#HTTP404NOTFOUND)
   }


### PR DESCRIPTION
With this PR, we make use of 2 query params `includePrerelease` and `includeSnapshots` when searching for compatible versions of a package. 

Corresponding client-side changes are made in the IPM repo (for release with 0.9.0)

Note: pursuant to the discussion [here](https://github.com/intersystems-community/zpm-registry/issues/91#issuecomment-2312599952), we consider **_snapshot_** as a version with a prerelease tag of the string literal "snapshot". A version with any other non-empty prerelease tag is called a **_prerelease_**.

Fixes #91 