### PR TITLE
fix: include prerelease and snapshot by default for compat with older zpm

### DIFF
--- a/src/cls/ZPM/Package.cls
+++ b/src/cls/ZPM/Package.cls
@@ -140,8 +140,8 @@ Method versionsGet() As %ListOfDataTypes
   Set tList = ##class(%ListOfDataTypes).%New()
 
   Set name = ..name
-  Set tPrerelease = $Select($Data(%request) # 2: %request.Get("includePrerelease", 0), 1: 1)
-  Set tSnapshot = $Select($Data(%request) # 2: %request.Get("includeSnapshots", 0), 1: 1)
+  Set tPrerelease = $Select($Data(%request) # 2: %request.Get("includePrerelease", 1), 1: 1)
+  Set tSnapshot = $Select($Data(%request) # 2: %request.Get("includeSnapshots", 1), 1: 1)
   &sql(
     SELECT %DLIST(version) INTO :versions 
     FROM Package 

--- a/src/cls/ZPM/Registry.cls
+++ b/src/cls/ZPM/Registry.cls
@@ -117,8 +117,8 @@ ClassMethod Package(pkg As %String = "", version As %String = "", platformVersio
   If (version="") {
     $$$ThrowOnError(##class(ZPM.UpLink).FindPackageInAllUpLinks(pkg))
   }
-  Set tIncludePrerelease = %request.Get("includePrerelease", 0)
-  Set tIncludeSnapshots = %request.Get("includeSnapshots", 0)
+  Set tIncludePrerelease = %request.Get("includePrerelease", 1)
+  Set tIncludeSnapshots = %request.Get("includeSnapshots", 1)
 
   Set version = ##class(ZPM.Package).VersionFind(pkg, version, tIncludePrerelease, tIncludeSnapshots)
   If (version = "") {


### PR DESCRIPTION
Legacy zpm users have been getting snapshots and prereleases regardless of their repo level settings. The newer version of registry shouldn't change this behavior on older versions of zpm. Hence we consider the default value of includePrerelease and includeSnapshots to `1` instead of `0`.

This should also fix the CI failures in https://github.com/intersystems/ipm/pull/561 and https://github.com/intersystems/ipm/pull/559.