### PR TITLE
Update IRIS Community version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM intersystems/iris-community:2024.1
+FROM intersystems/iris-community:2025.1
 
 WORKDIR /opt/registry
 


### PR DESCRIPTION
Updating to 2025.1 because 2024.1 has an expired license.